### PR TITLE
Change package name to gi-gst-editing-services

### DIFF
--- a/gi-gst-editing-services.opam
+++ b/gi-gst-editing-services.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "gst-editing-services"
+name: "gi-gst-editing-services"
 version: "~unknown"
 maintainer: "Manas Jayanth<prometheansacrifice@gmail.com>"
 authors: "Manas Jayanth <prometheansacrifice@gmail.com>"

--- a/lib/dune
+++ b/lib/dune
@@ -30,7 +30,7 @@
 
 (library
  (name        GstEditingServices)
-  (public_name gst-editing-services)
+  (public_name gi-gst-editing-services)
   (libraries ctypes ctypes.foreign gi-glib2 gstreamer)
   (c_names         dyn_load_constants_stubs)
   (c_flags         (:include c_flags.sexp))


### PR DESCRIPTION
I added the `gi-` prefix for the GLib2 package because user can directly see that it is generated with gobject-introspection. I changed the name of the package for the sake of consistency.